### PR TITLE
media-plugins/vapoursynth-fft3dfilter: drop gcc10 patch from 9999

### DIFF
--- a/media-plugins/vapoursynth-fft3dfilter/vapoursynth-fft3dfilter-9999-r2.ebuild
+++ b/media-plugins/vapoursynth-fft3dfilter/vapoursynth-fft3dfilter-9999-r2.ebuild
@@ -32,10 +32,6 @@ DEPEND="${RDEPEND}
 
 DOCS=( "doc/fft3dfilter.md" )
 
-PATCHES=(
-	"${FILESDIR}/fix-gcc10.patch"
-)
-
 src_configure() {
 	local emesonargs=(
 		--libdir="/usr/$(get_libdir)/vapoursynth/"


### PR DESCRIPTION
The live version of FFT3DFilter doesn't need the gcc10 patch anymore, because [it's fixed upstream.](https://github.com/myrsloik/VapourSynth-FFT3DFilter/commit/a9d11ddc13d76be4a492d0ef7bd173836e7ae506)