### PR TITLE
vapoursynth-vfrtocfr: Fix installation directory.

### DIFF
--- a/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-1.0.2017.07.21.ebuild
+++ b/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-1.0.2017.07.21.ebuild
@@ -27,7 +27,7 @@ DOCS=( "README.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="/usr/$(get_libdir)"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-9999.ebuild
+++ b/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="/usr/$(get_libdir)"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure


### PR DESCRIPTION
Vapoursynth-VFRToCFR's [meson.build](https://github.com/Irrational-Encoding-Wizardry/Vapoursynth-VFRToCFR/blob/d00a3743db70b928f3b0529d54f21aeae93d9db8/meson.build#L22) automatically appends `vapoursynth` to `--libdir`.  The original ebuild would install the plugin to `/usr/lib64/vapoursynth/vapoursynth` instead of `/usr/lib64/vapoursynth`.