### PR TITLE
app-editors/vapoursynth-editor: Fix errors

### DIFF
--- a/app-editors/vapoursynth-editor/vapoursynth-editor-19-r1.ebuild
+++ b/app-editors/vapoursynth-editor/vapoursynth-editor-19-r1.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit eutils qmake-utils xdg-utils
+inherit eutils qmake-utils xdg-utils desktop
 
 DESCRIPTION="VapourSynth Editor"
 HOMEPAGE="https://bitbucket.org/mystery_keeper/vapoursynth-editor"

--- a/app-editors/vapoursynth-editor/vapoursynth-editor-9999-r1.ebuild
+++ b/app-editors/vapoursynth-editor/vapoursynth-editor-9999-r1.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit eutils qmake-utils xdg-utils
+inherit eutils qmake-utils xdg-utils desktop
 
 DESCRIPTION="VapourSynth Editor"
 HOMEPAGE="https://bitbucket.org/mystery_keeper/vapoursynth-editor"


### PR DESCRIPTION
The 'qmake-utils' eclass dropped support for EAPI=6,
and the 'doicon' command is available in the 'desktop' eclass.