### PR TITLE
media-plugins/vapoursynth-havsfunc: 9999 requires vsutil

### DIFF
--- a/media-plugins/vapoursynth-havsfunc/vapoursynth-havsfunc-9999-r1.ebuild
+++ b/media-plugins/vapoursynth-havsfunc/vapoursynth-havsfunc-9999-r1.ebuild
@@ -52,6 +52,7 @@ RDEPEND+="
 	media-plugins/vapoursynth-temporalsoften2
 	media-plugins/vapoursynth-ttempsmooth
 	media-plugins/vapoursynth-znedi3
+	media-plugins/vsutil
 "
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
There was a [commit back in January](https://github.com/HomeOfVapourSynthEvolution/havsfunc/commit/d8cbaa3c3c73f14d250261ec66e16460c5a4a497) to havsfunc that made `vsutil` a required dependency.

NOTE: r33 Is not compatible with newer versions of vapoursynth (starting at r57) See: [havsfunc issue 44](https://github.com/HomeOfVapourSynthEvolution/havsfunc/issues/44)