### PR TITLE
add EPREFIX

### DIFF
--- a/media-libs/l-smash/l-smash-2.14.5.ebuild
+++ b/media-libs/l-smash/l-smash-2.14.5.ebuild
@@ -37,8 +37,8 @@ src_configure() {
 	fi
 
 	./configure \
-		--prefix=/usr \
-		--libdir=/usr/$(get_libdir) \
+		--prefix="${EPREFIX}"/usr \
+		--libdir="${EPREFIX}"/usr/$(get_libdir) \
 		--extra-cflags="${CFLAGS}" \
 		--extra-ldflags="${LDFLAGS}" \
 		${myconf}  || die

--- a/media-libs/l-smash/l-smash-9999.ebuild
+++ b/media-libs/l-smash/l-smash-9999.ebuild
@@ -37,8 +37,8 @@ src_configure() {
 	fi
 
 	./configure \
-		--prefix=/usr \
-		--libdir=/usr/$(get_libdir) \
+		--prefix="${EPREFIX}"/usr \
+		--libdir="${EPREFIX}"/usr/$(get_libdir) \
 		--extra-cflags="${CFLAGS}" \
 		--extra-ldflags="${LDFLAGS}" \
 		${myconf}  || die

--- a/media-plugins/bestaudiosource/bestaudiosource-1.ebuild
+++ b/media-plugins/bestaudiosource/bestaudiosource-1.ebuild
@@ -35,7 +35,7 @@ PATCHES=( "${FILESDIR}/${P}-limits.patch" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/bestaudiosource/bestaudiosource-9999.ebuild
+++ b/media-plugins/bestaudiosource/bestaudiosource-9999.ebuild
@@ -33,7 +33,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/subtext/subtext-3.ebuild
+++ b/media-plugins/subtext/subtext-3.ebuild
@@ -34,7 +34,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/subtext/subtext-9999.ebuild
+++ b/media-plugins/subtext/subtext-9999.ebuild
@@ -34,7 +34,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-addgrain/vapoursynth-addgrain-10.ebuild
+++ b/media-plugins/vapoursynth-addgrain/vapoursynth-addgrain-10.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-addgrain/vapoursynth-addgrain-9999.ebuild
+++ b/media-plugins/vapoursynth-addgrain/vapoursynth-addgrain-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-asharp/vapoursynth-asharp-1.ebuild
+++ b/media-plugins/vapoursynth-asharp/vapoursynth-asharp-1.ebuild
@@ -33,7 +33,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-asharp/vapoursynth-asharp-9999.ebuild
+++ b/media-plugins/vapoursynth-asharp/vapoursynth-asharp-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-awarpsharp2/vapoursynth-awarpsharp2-4.ebuild
+++ b/media-plugins/vapoursynth-awarpsharp2/vapoursynth-awarpsharp2-4.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-awarpsharp2/vapoursynth-awarpsharp2-9999.ebuild
+++ b/media-plugins/vapoursynth-awarpsharp2/vapoursynth-awarpsharp2-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-beziercurve/vapoursynth-beziercurve-3.ebuild
+++ b/media-plugins/vapoursynth-beziercurve/vapoursynth-beziercurve-3.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-beziercurve/vapoursynth-beziercurve-9999.ebuild
+++ b/media-plugins/vapoursynth-beziercurve/vapoursynth-beziercurve-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-bifrost/vapoursynth-bifrost-2.2.ebuild
+++ b/media-plugins/vapoursynth-bifrost/vapoursynth-bifrost-2.2.ebuild
@@ -35,5 +35,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-bifrost/vapoursynth-bifrost-9999.ebuild
+++ b/media-plugins/vapoursynth-bifrost/vapoursynth-bifrost-9999.ebuild
@@ -35,5 +35,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-bm3d/vapoursynth-bm3d-9.ebuild
+++ b/media-plugins/vapoursynth-bm3d/vapoursynth-bm3d-9.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-bm3d/vapoursynth-bm3d-9999.ebuild
+++ b/media-plugins/vapoursynth-bm3d/vapoursynth-bm3d-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-bwdif/vapoursynth-bwdif-4.1.ebuild
+++ b/media-plugins/vapoursynth-bwdif/vapoursynth-bwdif-4.1.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-bwdif/vapoursynth-bwdif-9999.ebuild
+++ b/media-plugins/vapoursynth-bwdif/vapoursynth-bwdif-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-cas/vapoursynth-cas-2.ebuild
+++ b/media-plugins/vapoursynth-cas/vapoursynth-cas-2.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-cas/vapoursynth-cas-9999.ebuild
+++ b/media-plugins/vapoursynth-cas/vapoursynth-cas-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-cmedian/vapoursynth-cmedian-1-r1.ebuild
+++ b/media-plugins/vapoursynth-cmedian/vapoursynth-cmedian-1-r1.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-cmedian/vapoursynth-cmedian-9999.ebuild
+++ b/media-plugins/vapoursynth-cmedian/vapoursynth-cmedian-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-cnr2/vapoursynth-cnr2-1.ebuild
+++ b/media-plugins/vapoursynth-cnr2/vapoursynth-cnr2-1.ebuild
@@ -35,7 +35,7 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }
 
 src_install() {

--- a/media-plugins/vapoursynth-cnr2/vapoursynth-cnr2-9999.ebuild
+++ b/media-plugins/vapoursynth-cnr2/vapoursynth-cnr2-9999.ebuild
@@ -35,7 +35,7 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }
 
 src_install() {

--- a/media-plugins/vapoursynth-colorbars/vapoursynth-colorbars-3.ebuild
+++ b/media-plugins/vapoursynth-colorbars/vapoursynth-colorbars-3.ebuild
@@ -32,5 +32,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-colorbars/vapoursynth-colorbars-9999.ebuild
+++ b/media-plugins/vapoursynth-colorbars/vapoursynth-colorbars-9999.ebuild
@@ -32,5 +32,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-ctmf/vapoursynth-ctmf-5.ebuild
+++ b/media-plugins/vapoursynth-ctmf/vapoursynth-ctmf-5.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-ctmf/vapoursynth-ctmf-9999.ebuild
+++ b/media-plugins/vapoursynth-ctmf/vapoursynth-ctmf-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-curve/vapoursynth-curve-3.ebuild
+++ b/media-plugins/vapoursynth-curve/vapoursynth-curve-3.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-curve/vapoursynth-curve-9999.ebuild
+++ b/media-plugins/vapoursynth-curve/vapoursynth-curve-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-d2vsource/vapoursynth-d2vsource-1.3_pre20211103.ebuild
+++ b/media-plugins/vapoursynth-d2vsource/vapoursynth-d2vsource-1.3_pre20211103.ebuild
@@ -31,5 +31,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf  --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf  --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-d2vsource/vapoursynth-d2vsource-9999.ebuild
+++ b/media-plugins/vapoursynth-d2vsource/vapoursynth-d2vsource-9999.ebuild
@@ -37,5 +37,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf  --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf  --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-dctfilter/vapoursynth-dctfilter-2.1.ebuild
+++ b/media-plugins/vapoursynth-dctfilter/vapoursynth-dctfilter-2.1.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-dctfilter/vapoursynth-dctfilter-9999.ebuild
+++ b/media-plugins/vapoursynth-dctfilter/vapoursynth-dctfilter-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-deblock/vapoursynth-deblock-6.1.ebuild
+++ b/media-plugins/vapoursynth-deblock/vapoursynth-deblock-6.1.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 	)
 	meson_src_configure
 }

--- a/media-plugins/vapoursynth-deblock/vapoursynth-deblock-9999.ebuild
+++ b/media-plugins/vapoursynth-deblock/vapoursynth-deblock-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 	)
 	meson_src_configure
 }

--- a/media-plugins/vapoursynth-deblockpp7/vapoursynth-deblockpp7-4.1.ebuild
+++ b/media-plugins/vapoursynth-deblockpp7/vapoursynth-deblockpp7-4.1.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-deblockpp7/vapoursynth-deblockpp7-9999.ebuild
+++ b/media-plugins/vapoursynth-deblockpp7/vapoursynth-deblockpp7-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-decross/vapoursynth-decross-1.ebuild
+++ b/media-plugins/vapoursynth-decross/vapoursynth-decross-1.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-decross/vapoursynth-decross-9999.ebuild
+++ b/media-plugins/vapoursynth-decross/vapoursynth-decross-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-dedot/vapoursynth-dedot-1.ebuild
+++ b/media-plugins/vapoursynth-dedot/vapoursynth-dedot-1.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-dedot/vapoursynth-dedot-9999.ebuild
+++ b/media-plugins/vapoursynth-dedot/vapoursynth-dedot-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-degrainmedian/vapoursynth-degrainmedian-1.ebuild
+++ b/media-plugins/vapoursynth-degrainmedian/vapoursynth-degrainmedian-1.ebuild
@@ -33,5 +33,5 @@ src_prepare() {
 
 src_configure() {
 	if use doc; then DOCS=( readme.rst ); fi
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-degrainmedian/vapoursynth-degrainmedian-9999.ebuild
+++ b/media-plugins/vapoursynth-degrainmedian/vapoursynth-degrainmedian-9999.ebuild
@@ -33,5 +33,5 @@ src_prepare() {
 
 src_configure() {
 	if use doc; then DOCS=( readme.rst ); fi
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-dfttest/vapoursynth-dfttest-7.ebuild
+++ b/media-plugins/vapoursynth-dfttest/vapoursynth-dfttest-7.ebuild
@@ -35,7 +35,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-dfttest/vapoursynth-dfttest-9999.ebuild
+++ b/media-plugins/vapoursynth-dfttest/vapoursynth-dfttest-9999.ebuild
@@ -35,7 +35,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-eedi2/vapoursynth-eedi2-7.1.ebuild
+++ b/media-plugins/vapoursynth-eedi2/vapoursynth-eedi2-7.1.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 	)
 	meson_src_configure
 }

--- a/media-plugins/vapoursynth-eedi2/vapoursynth-eedi2-9999.ebuild
+++ b/media-plugins/vapoursynth-eedi2/vapoursynth-eedi2-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 	)
 	meson_src_configure
 }

--- a/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-4.ebuild
+++ b/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-4.ebuild
@@ -37,7 +37,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 		-Dopencl=$(usex opencl true false)
 	)

--- a/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-9999.ebuild
+++ b/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-9999.ebuild
@@ -37,7 +37,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 		-Dopencl=$(usex opencl true false)
 	)

--- a/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-2.40.ebuild
+++ b/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-2.40.ebuild
@@ -27,5 +27,5 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}"
 
 src_install() {
-	dosym /usr/$(get_libdir)/libffms2.so.4.0.0 /usr/$(get_libdir)/vapoursynth/libffms2.so || die
+	dosym ${EPREFIX}/usr/$(get_libdir)/libffms2.so.4.0.0 /usr/$(get_libdir)/vapoursynth/libffms2.so || die
 }

--- a/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-9999.ebuild
+++ b/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-9999.ebuild
@@ -27,5 +27,5 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}"
 
 src_install() {
-	dosym /usr/$(get_libdir)/libffms2.so.4.0.0 /usr/$(get_libdir)/vapoursynth/libffms2.so || die
+	dosym ${EPREFIX}/usr/$(get_libdir)/libffms2.so.4.0.0 /usr/$(get_libdir)/vapoursynth/libffms2.so || die
 }

--- a/media-plugins/vapoursynth-fft3dfilter/vapoursynth-fft3dfilter-2.ebuild
+++ b/media-plugins/vapoursynth-fft3dfilter/vapoursynth-fft3dfilter-2.ebuild
@@ -35,7 +35,7 @@ DOCS=( "doc/fft3dfilter.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-fft3dfilter/vapoursynth-fft3dfilter-9999.ebuild
+++ b/media-plugins/vapoursynth-fft3dfilter/vapoursynth-fft3dfilter-9999.ebuild
@@ -35,7 +35,7 @@ DOCS=( "doc/fft3dfilter.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-fieldhint/vapoursynth-fieldhint-3.ebuild
+++ b/media-plugins/vapoursynth-fieldhint/vapoursynth-fieldhint-3.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-fieldhint/vapoursynth-fieldhint-9999.ebuild
+++ b/media-plugins/vapoursynth-fieldhint/vapoursynth-fieldhint-9999.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-fillborders/vapoursynth-fillborders-2.ebuild
+++ b/media-plugins/vapoursynth-fillborders/vapoursynth-fillborders-2.ebuild
@@ -31,7 +31,7 @@ DOCS=( readme.rst )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 	)
 	meson_src_configure
 }

--- a/media-plugins/vapoursynth-fillborders/vapoursynth-fillborders-9999.ebuild
+++ b/media-plugins/vapoursynth-fillborders/vapoursynth-fillborders-9999.ebuild
@@ -31,7 +31,7 @@ DOCS=( readme.rst )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 	)
 	meson_src_configure
 }

--- a/media-plugins/vapoursynth-fix-telecined-fades/vapoursynth-fix-telecined-fades-6_pre20170224.ebuild
+++ b/media-plugins/vapoursynth-fix-telecined-fades/vapoursynth-fix-telecined-fades-6_pre20170224.ebuild
@@ -28,7 +28,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-fix-telecined-fades/vapoursynth-fix-telecined-fades-9999.ebuild
+++ b/media-plugins/vapoursynth-fix-telecined-fades/vapoursynth-fix-telecined-fades-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-fluxsmooth/vapoursynth-fluxsmooth-2.ebuild
+++ b/media-plugins/vapoursynth-fluxsmooth/vapoursynth-fluxsmooth-2.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-fluxsmooth/vapoursynth-fluxsmooth-9999.ebuild
+++ b/media-plugins/vapoursynth-fluxsmooth/vapoursynth-fluxsmooth-9999.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-fmtconv/vapoursynth-fmtconv-30.ebuild
+++ b/media-plugins/vapoursynth-fmtconv/vapoursynth-fmtconv-30.ebuild
@@ -37,5 +37,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-fmtconv/vapoursynth-fmtconv-9999.ebuild
+++ b/media-plugins/vapoursynth-fmtconv/vapoursynth-fmtconv-9999.ebuild
@@ -37,5 +37,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-frfun7/vapoursynth-frfun7-2.ebuild
+++ b/media-plugins/vapoursynth-frfun7/vapoursynth-frfun7-2.ebuild
@@ -31,7 +31,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-frfun7/vapoursynth-frfun7-9999.ebuild
+++ b/media-plugins/vapoursynth-frfun7/vapoursynth-frfun7-9999.ebuild
@@ -31,7 +31,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-histogram/vapoursynth-histogram-2-r1.ebuild
+++ b/media-plugins/vapoursynth-histogram/vapoursynth-histogram-2-r1.ebuild
@@ -27,5 +27,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-histogram/vapoursynth-histogram-9999.ebuild
+++ b/media-plugins/vapoursynth-histogram/vapoursynth-histogram-9999.ebuild
@@ -31,5 +31,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-hqdn3d/vapoursynth-hqdn3d-20180329.ebuild
+++ b/media-plugins/vapoursynth-hqdn3d/vapoursynth-hqdn3d-20180329.ebuild
@@ -24,5 +24,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-hqdn3d/vapoursynth-hqdn3d-99999999.ebuild
+++ b/media-plugins/vapoursynth-hqdn3d/vapoursynth-hqdn3d-99999999.ebuild
@@ -29,5 +29,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-l-smash-works/vapoursynth-l-smash-works-20220505.ebuild
+++ b/media-plugins/vapoursynth-l-smash-works/vapoursynth-l-smash-works-20220505.ebuild
@@ -37,7 +37,7 @@ DOCS=( "README" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-l-smash-works/vapoursynth-l-smash-works-99999999.ebuild
+++ b/media-plugins/vapoursynth-l-smash-works/vapoursynth-l-smash-works-99999999.ebuild
@@ -37,7 +37,7 @@ DOCS=( "README" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-lghost/vapoursynth-lghost-1.ebuild
+++ b/media-plugins/vapoursynth-lghost/vapoursynth-lghost-1.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-lghost/vapoursynth-lghost-9999.ebuild
+++ b/media-plugins/vapoursynth-lghost/vapoursynth-lghost-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-matchhistogram/vapoursynth-matchhistogram-2.ebuild
+++ b/media-plugins/vapoursynth-matchhistogram/vapoursynth-matchhistogram-2.ebuild
@@ -33,7 +33,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-matchhistogram/vapoursynth-matchhistogram-9999.ebuild
+++ b/media-plugins/vapoursynth-matchhistogram/vapoursynth-matchhistogram-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-median/vapoursynth-median-4.ebuild
+++ b/media-plugins/vapoursynth-median/vapoursynth-median-4.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-median/vapoursynth-median-9999.ebuild
+++ b/media-plugins/vapoursynth-median/vapoursynth-median-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-minideen/vapoursynth-minideen-2.ebuild
+++ b/media-plugins/vapoursynth-minideen/vapoursynth-minideen-2.ebuild
@@ -34,7 +34,7 @@ DOCS=( "readme.rst" )
 src_configure() {
 	append-cxxflags $(test-flags-CXX -fpeel-loops)
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-minideen/vapoursynth-minideen-9999.ebuild
+++ b/media-plugins/vapoursynth-minideen/vapoursynth-minideen-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "readme.rst" )
 src_configure() {
 	append-cxxflags $(test-flags-CXX -fpeel-loops)
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-minsrp/vapoursynth-minsrp-4-r4.ebuild
+++ b/media-plugins/vapoursynth-minsrp/vapoursynth-minsrp-4-r4.ebuild
@@ -41,7 +41,7 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }
 
 src_install() {

--- a/media-plugins/vapoursynth-minsrp/vapoursynth-minsrp-9999.ebuild
+++ b/media-plugins/vapoursynth-minsrp/vapoursynth-minsrp-9999.ebuild
@@ -41,7 +41,7 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }
 
 src_install() {

--- a/media-plugins/vapoursynth-miscfilters-obsolete/vapoursynth-miscfilters-obsolete-2.ebuild
+++ b/media-plugins/vapoursynth-miscfilters-obsolete/vapoursynth-miscfilters-obsolete-2.ebuild
@@ -28,7 +28,7 @@ DOCS=( "docs/misc.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-miscfilters-obsolete/vapoursynth-miscfilters-obsolete-9999.ebuild
+++ b/media-plugins/vapoursynth-miscfilters-obsolete/vapoursynth-miscfilters-obsolete-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "docs/misc.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-motionmask/vapoursynth-motionmask-2.ebuild
+++ b/media-plugins/vapoursynth-motionmask/vapoursynth-motionmask-2.ebuild
@@ -27,7 +27,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-motionmask/vapoursynth-motionmask-9999.ebuild
+++ b/media-plugins/vapoursynth-motionmask/vapoursynth-motionmask-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-msmoosh/vapoursynth-msmoosh-1.1.ebuild
+++ b/media-plugins/vapoursynth-msmoosh/vapoursynth-msmoosh-1.1.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-msmoosh/vapoursynth-msmoosh-9999.ebuild
+++ b/media-plugins/vapoursynth-msmoosh/vapoursynth-msmoosh-9999.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-mvtools/vapoursynth-mvtools-23.ebuild
+++ b/media-plugins/vapoursynth-mvtools/vapoursynth-mvtools-23.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-mvtools/vapoursynth-mvtools-9999.ebuild
+++ b/media-plugins/vapoursynth-mvtools/vapoursynth-mvtools-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-nnedi3/vapoursynth-nnedi3-12.ebuild
+++ b/media-plugins/vapoursynth-nnedi3/vapoursynth-nnedi3-12.ebuild
@@ -20,6 +20,7 @@ LICENSE="GPL-2"
 SLOT="0"
 
 RDEPEND+="
+	dev-lang/yasm
 	media-libs/vapoursynth
 "
 DEPEND="${RDEPEND}
@@ -34,5 +35,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-nnedi3/vapoursynth-nnedi3-9999.ebuild
+++ b/media-plugins/vapoursynth-nnedi3/vapoursynth-nnedi3-9999.ebuild
@@ -20,6 +20,7 @@ LICENSE="GPL-2"
 SLOT="0"
 
 RDEPEND+="
+	dev-lang/yasm
 	media-libs/vapoursynth
 "
 DEPEND="${RDEPEND}
@@ -34,5 +35,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-8.ebuild
+++ b/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-8.ebuild
@@ -36,7 +36,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-9999.ebuild
+++ b/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-9999.ebuild
@@ -36,7 +36,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-readmpls/vapoursynth-readmpls-5.ebuild
+++ b/media-plugins/vapoursynth-readmpls/vapoursynth-readmpls-5.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-readmpls/vapoursynth-readmpls-9999.ebuild
+++ b/media-plugins/vapoursynth-readmpls/vapoursynth-readmpls-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-remapframes/vapoursynth-remapframes-1.1.ebuild
+++ b/media-plugins/vapoursynth-remapframes/vapoursynth-remapframes-1.1.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-remapframes/vapoursynth-remapframes-9999.ebuild
+++ b/media-plugins/vapoursynth-remapframes/vapoursynth-remapframes-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-retinex/vapoursynth-retinex-4.ebuild
+++ b/media-plugins/vapoursynth-retinex/vapoursynth-retinex-4.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-retinex/vapoursynth-retinex-9999.ebuild
+++ b/media-plugins/vapoursynth-retinex/vapoursynth-retinex-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9.ebuild
+++ b/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9.ebuild
@@ -35,7 +35,7 @@ BDEPEND="dev-util/ninja"
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Duse_system_ncnn=true
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9999.ebuild
+++ b/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9999.ebuild
@@ -35,7 +35,7 @@ BDEPEND="dev-util/ninja"
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Duse_system_ncnn=true
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-sangnom/vapoursynth-sangnom-42.ebuild
+++ b/media-plugins/vapoursynth-sangnom/vapoursynth-sangnom-42.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-sangnom/vapoursynth-sangnom-9999.ebuild
+++ b/media-plugins/vapoursynth-sangnom/vapoursynth-sangnom-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-scxvid/vapoursynth-scxvid-1.ebuild
+++ b/media-plugins/vapoursynth-scxvid/vapoursynth-scxvid-1.ebuild
@@ -35,5 +35,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-scxvid/vapoursynth-scxvid-9999.ebuild
+++ b/media-plugins/vapoursynth-scxvid/vapoursynth-scxvid-9999.ebuild
@@ -35,5 +35,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-smoothuv/vapoursynth-smoothuv-3.ebuild
+++ b/media-plugins/vapoursynth-smoothuv/vapoursynth-smoothuv-3.ebuild
@@ -38,7 +38,7 @@ DOCS=( "readme.rst" )
 src_configure() {
 	append-cxxflags $(test-flags-CXX -fpeel-loops)
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-smoothuv/vapoursynth-smoothuv-9999.ebuild
+++ b/media-plugins/vapoursynth-smoothuv/vapoursynth-smoothuv-9999.ebuild
@@ -38,7 +38,7 @@ DOCS=( "readme.rst" )
 src_configure() {
 	append-cxxflags $(test-flags-CXX -fpeel-loops)
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-ssiq/vapoursynth-ssiq-1.0.ebuild
+++ b/media-plugins/vapoursynth-ssiq/vapoursynth-ssiq-1.0.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-ssiq/vapoursynth-ssiq-9999.ebuild
+++ b/media-plugins/vapoursynth-ssiq/vapoursynth-ssiq-9999.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-tbilateral/vapoursynth-tbilateral-4.ebuild
+++ b/media-plugins/vapoursynth-tbilateral/vapoursynth-tbilateral-4.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tbilateral/vapoursynth-tbilateral-9999.ebuild
+++ b/media-plugins/vapoursynth-tbilateral/vapoursynth-tbilateral-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tcanny/vapoursynth-tcanny-14.ebuild
+++ b/media-plugins/vapoursynth-tcanny/vapoursynth-tcanny-14.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tcanny/vapoursynth-tcanny-9999.ebuild
+++ b/media-plugins/vapoursynth-tcanny/vapoursynth-tcanny-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tcomb/vapoursynth-tcomb-4.ebuild
+++ b/media-plugins/vapoursynth-tcomb/vapoursynth-tcomb-4.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-tcomb/vapoursynth-tcomb-9999.ebuild
+++ b/media-plugins/vapoursynth-tcomb/vapoursynth-tcomb-9999.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-tdeintmod/vapoursynth-tdeintmod-10.1.ebuild
+++ b/media-plugins/vapoursynth-tdeintmod/vapoursynth-tdeintmod-10.1.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tdeintmod/vapoursynth-tdeintmod-9999.ebuild
+++ b/media-plugins/vapoursynth-tdeintmod/vapoursynth-tdeintmod-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tedgemask/vapoursynth-tedgemask-1.ebuild
+++ b/media-plugins/vapoursynth-tedgemask/vapoursynth-tedgemask-1.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tedgemask/vapoursynth-tedgemask-9999.ebuild
+++ b/media-plugins/vapoursynth-tedgemask/vapoursynth-tedgemask-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-temporalmedian/vapoursynth-temporalmedian-1.ebuild
+++ b/media-plugins/vapoursynth-temporalmedian/vapoursynth-temporalmedian-1.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-temporalmedian/vapoursynth-temporalmedian-9999.ebuild
+++ b/media-plugins/vapoursynth-temporalmedian/vapoursynth-temporalmedian-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-temporalsoften/vapoursynth-temporalsoften-1.0.ebuild
+++ b/media-plugins/vapoursynth-temporalsoften/vapoursynth-temporalsoften-1.0.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-temporalsoften/vapoursynth-temporalsoften-9999.ebuild
+++ b/media-plugins/vapoursynth-temporalsoften/vapoursynth-temporalsoften-9999.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-temporalsoften2/vapoursynth-temporalsoften2-1-r1.ebuild
+++ b/media-plugins/vapoursynth-temporalsoften2/vapoursynth-temporalsoften2-1-r1.ebuild
@@ -27,7 +27,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-temporalsoften2/vapoursynth-temporalsoften2-9999.ebuild
+++ b/media-plugins/vapoursynth-temporalsoften2/vapoursynth-temporalsoften2-9999.ebuild
@@ -32,7 +32,7 @@ DOCS=( "readme.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tivtc/vapoursynth-tivtc-2.ebuild
+++ b/media-plugins/vapoursynth-tivtc/vapoursynth-tivtc-2.ebuild
@@ -30,7 +30,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tivtc/vapoursynth-tivtc-9999.ebuild
+++ b/media-plugins/vapoursynth-tivtc/vapoursynth-tivtc-9999.ebuild
@@ -30,7 +30,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-tonemap/vapoursynth-tonemap-2.ebuild
+++ b/media-plugins/vapoursynth-tonemap/vapoursynth-tonemap-2.ebuild
@@ -29,5 +29,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-tonemap/vapoursynth-tonemap-9999.ebuild
+++ b/media-plugins/vapoursynth-tonemap/vapoursynth-tonemap-9999.ebuild
@@ -29,5 +29,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-ttempsmooth/vapoursynth-ttempsmooth-4.1.ebuild
+++ b/media-plugins/vapoursynth-ttempsmooth/vapoursynth-ttempsmooth-4.1.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-ttempsmooth/vapoursynth-ttempsmooth-9999.ebuild
+++ b/media-plugins/vapoursynth-ttempsmooth/vapoursynth-ttempsmooth-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vcm/vapoursynth-vcm-20220210.ebuild
+++ b/media-plugins/vapoursynth-vcm/vapoursynth-vcm-20220210.ebuild
@@ -19,6 +19,7 @@ IUSE="lto"
 
 RDEPEND+="
 	media-libs/vapoursynth
+	sci-libs/fftw
 "
 DEPEND="${RDEPEND}
 "
@@ -30,7 +31,7 @@ src_prepare() {
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vcm/vapoursynth-vcm-99999999.ebuild
+++ b/media-plugins/vapoursynth-vcm/vapoursynth-vcm-99999999.ebuild
@@ -24,6 +24,7 @@ IUSE="lto"
 
 RDEPEND+="
 	media-libs/vapoursynth
+	sci-libs/fftw
 "
 DEPEND="${RDEPEND}
 "
@@ -35,7 +36,7 @@ src_prepare() {
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-1.0-r1.ebuild
+++ b/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-1.0-r1.ebuild
@@ -27,7 +27,7 @@ DOCS=( "README.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)"
+		--libdir="${EPREFIX}/usr/$(get_libdir)"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-9999.ebuild
+++ b/media-plugins/vapoursynth-vfrtocrf/vapoursynth-vfrtocrf-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.rst" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)"
+		--libdir="${EPREFIX}/usr/$(get_libdir)"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-videoscope/vapoursynth-videoscope-1.0.ebuild
+++ b/media-plugins/vapoursynth-videoscope/vapoursynth-videoscope-1.0.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-videoscope/vapoursynth-videoscope-9999.ebuild
+++ b/media-plugins/vapoursynth-videoscope/vapoursynth-videoscope-9999.ebuild
@@ -34,5 +34,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-10.ebuild
+++ b/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-10.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-9999.ebuild
+++ b/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vsrawsource/vapoursynth-vsrawsource-20191105.ebuild
+++ b/media-plugins/vapoursynth-vsrawsource/vapoursynth-vsrawsource-20191105.ebuild
@@ -33,7 +33,7 @@ DOCS=( "readme.rst" "format_list.txt" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-vsrawsource/vapoursynth-vsrawsource-99999999.ebuild
+++ b/media-plugins/vapoursynth-vsrawsource/vapoursynth-vsrawsource-99999999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "readme.rst" "format_list.txt" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-waifu2x-w2xc/vapoursynth-waifu2x-w2xc-8.ebuild
+++ b/media-plugins/vapoursynth-waifu2x-w2xc/vapoursynth-waifu2x-w2xc-8.ebuild
@@ -28,7 +28,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-waifu2x-w2xc/vapoursynth-waifu2x-w2xc-9999.ebuild
+++ b/media-plugins/vapoursynth-waifu2x-w2xc/vapoursynth-waifu2x-w2xc-9999.ebuild
@@ -34,7 +34,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-yadifmod/vapoursynth-yadifmod-10.1.ebuild
+++ b/media-plugins/vapoursynth-yadifmod/vapoursynth-yadifmod-10.1.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vapoursynth-yadifmod/vapoursynth-yadifmod-9999.ebuild
+++ b/media-plugins/vapoursynth-yadifmod/vapoursynth-yadifmod-9999.ebuild
@@ -33,7 +33,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vivtc/vivtc-1.ebuild
+++ b/media-plugins/vivtc/vivtc-1.ebuild
@@ -33,7 +33,7 @@ PATCHES=( "${FILESDIR}/${P}-meson.patch" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vivtc/vivtc-9999.ebuild
+++ b/media-plugins/vivtc/vivtc-9999.ebuild
@@ -32,7 +32,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-ccd/vs-ccd-0.3.1-r1.ebuild
+++ b/media-plugins/vs-ccd/vs-ccd-0.3.1-r1.ebuild
@@ -30,7 +30,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-ccd/vs-ccd-9999.ebuild
+++ b/media-plugins/vs-ccd/vs-ccd-9999.ebuild
@@ -35,7 +35,7 @@ DOCS=( "README.md" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-imwri/vs-imwri-2.ebuild
+++ b/media-plugins/vs-imwri/vs-imwri-2.ebuild
@@ -36,7 +36,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-imwri/vs-imwri-9999.ebuild
+++ b/media-plugins/vs-imwri/vs-imwri-9999.ebuild
@@ -36,7 +36,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-ocr/vs-ocr-1.ebuild
+++ b/media-plugins/vs-ocr/vs-ocr-1.ebuild
@@ -35,7 +35,7 @@ PATCHES=( "${FILESDIR}/${P}-meson.patch" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-ocr/vs-ocr-9999.ebuild
+++ b/media-plugins/vs-ocr/vs-ocr-9999.ebuild
@@ -33,7 +33,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-removegrain/vs-removegrain-1.ebuild
+++ b/media-plugins/vs-removegrain/vs-removegrain-1.ebuild
@@ -34,7 +34,7 @@ PATCHES=( "${FILESDIR}/${P}-meson.patch" )
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-plugins/vs-removegrain/vs-removegrain-9999.ebuild
+++ b/media-plugins/vs-removegrain/vs-removegrain-9999.ebuild
@@ -32,7 +32,7 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local emesonargs=(
-		--libdir="/usr/$(get_libdir)/vapoursynth/"
+		--libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 		-Db_lto=$(usex lto true false)
 	)
 	meson_src_configure

--- a/media-video/mpv/mpv-0.34.1-r101.ebuild
+++ b/media-video/mpv/mpv-0.34.1-r101.ebuild
@@ -267,7 +267,7 @@ src_configure() {
 
 	mywafargs+=(
 		--bashdir="$(get_bashcompdir)"
-		--zshdir="${EPREFIX}"/usr/share/zsh/site-functions
+		--zshdir=${EPREFIX}/usr/share/zsh/site-functions
 )
 
 	# Create reproducible non-live builds.
@@ -285,13 +285,13 @@ src_install() {
 	fi
 
 	if use cli && use lua_single_target_luajit; then
-		pax-mark -m "${ED}"/usr/bin/${PN}
+		pax-mark -m "${ED}"${EPREFIX}/usr/bin/${PN}
 	fi
 
 	if use tools; then
 		dobin TOOLS/{mpv_identify.sh,umpv}
 		newbin TOOLS/idet.sh mpv_idet.sh
-		python_replicate_script "${ED}"/usr/bin/umpv
+		python_replicate_script "${ED}"${EPREFIX}/usr/bin/umpv
 	fi
 }
 

--- a/media-video/mpv/mpv-9999-r1.ebuild
+++ b/media-video/mpv/mpv-9999-r1.ebuild
@@ -268,7 +268,7 @@ src_configure() {
 
 	mywafargs+=(
 		--bashdir="$(get_bashcompdir)"
-		--zshdir="${EPREFIX}"/usr/share/zsh/site-functions
+		--zshdir=${EPREFIX}/usr/share/zsh/site-functions
 )
 
 	# Create reproducible non-live builds.
@@ -286,13 +286,13 @@ src_install() {
 	fi
 
 	if use cli && use lua_single_target_luajit; then
-		pax-mark -m "${ED}"/usr/bin/${PN}
+		pax-mark -m "${ED}"${EPREFIX}/usr/bin/${PN}
 	fi
 
 	if use tools; then
 		dobin TOOLS/{mpv_identify.sh,umpv}
 		newbin TOOLS/idet.sh mpv_idet.sh
-		python_replicate_script "${ED}"/usr/bin/umpv
+		python_replicate_script "${ED}"${EPREFIX}/usr/bin/umpv
 	fi
 }
 

--- a/media-video/wobbly/wobbly-5.ebuild
+++ b/media-video/wobbly/wobbly-5.ebuild
@@ -38,5 +38,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }

--- a/media-video/wobbly/wobbly-9999.ebuild
+++ b/media-video/wobbly/wobbly-9999.ebuild
@@ -38,5 +38,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --libdir="/usr/$(get_libdir)/vapoursynth/"
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)/vapoursynth/"
 }


### PR DESCRIPTION
Add `${EPREFIX}` to ebuild files so they could work under gentoo prefix.

Add additional `RDEPEND` to vapoursynth-vcm & vapoursynth-nnedi3