### PR TITLE
Replace dependencies on `dev-libs/ocl-icd` by `dev-libs/opencl-icd-loader`.

### DIFF
--- a/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-4.ebuild
+++ b/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-4.ebuild
@@ -26,7 +26,7 @@ RDEPEND+="
 	media-libs/vapoursynth
 	opencl? ( 
 		virtual/opencl
-		dev-libs/ocl-icd
+		dev-libs/opencl-icd-loader
 	)
 "
 DEPEND="${RDEPEND}

--- a/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-9999.ebuild
+++ b/media-plugins/vapoursynth-eedi3/vapoursynth-eedi3-9999.ebuild
@@ -26,7 +26,7 @@ RDEPEND+="
 	media-libs/vapoursynth
 	opencl? ( 
 		virtual/opencl
-		dev-libs/ocl-icd
+		dev-libs/opencl-icd-loader
 	)
 "
 DEPEND="${RDEPEND}

--- a/media-plugins/vapoursynth-knlmeanscl/vapoursynth-knlmeanscl-1.1.1-r2.ebuild
+++ b/media-plugins/vapoursynth-knlmeanscl/vapoursynth-knlmeanscl-1.1.1-r2.ebuild
@@ -22,7 +22,7 @@ RDEPEND+="
 	virtual/opencl
 	video_cards_nvidia? (
 		x11-drivers/nvidia-drivers
-		dev-libs/ocl-icd
+		dev-libs/opencl-icd-loader
 		)
 "
 DEPEND="${RDEPEND}

--- a/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-8.ebuild
+++ b/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-8.ebuild
@@ -26,7 +26,7 @@ RDEPEND+="
 	media-libs/vapoursynth
 	dev-libs/boost
 	virtual/opencl
-	dev-libs/ocl-icd
+	dev-libs/opencl-icd-loader
 "
 DEPEND="${RDEPEND}
 "

--- a/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-9999.ebuild
+++ b/media-plugins/vapoursynth-nnedi3cl/vapoursynth-nnedi3cl-9999.ebuild
@@ -26,7 +26,7 @@ RDEPEND+="
 	media-libs/vapoursynth
 	dev-libs/boost
 	virtual/opencl
-	dev-libs/ocl-icd
+	dev-libs/opencl-icd-loader
 "
 DEPEND="${RDEPEND}
 "


### PR DESCRIPTION
`dev-libs/ocl-icd` is PMASKED in Gentoo's main tree.