### PR TITLE
media-plugins/vapoursynth-akarin: Fix llvm dep again

### DIFF
--- a/media-plugins/vapoursynth-akarin/vapoursynth-akarin-0.96f.ebuild
+++ b/media-plugins/vapoursynth-akarin/vapoursynth-akarin-0.96f.ebuild
@@ -28,7 +28,7 @@ RDEPEND+="
 "
 DEPEND="
 	${RDEPEND}
-	<=sys-devel/llvm-${LLVM_MAX_SLOT}
+	sys-devel/llvm:${LLVM_MAX_SLOT}
 "
 
 if ver_test ${PV} -ne 9999; then

--- a/media-plugins/vapoursynth-akarin/vapoursynth-akarin-9999.ebuild
+++ b/media-plugins/vapoursynth-akarin/vapoursynth-akarin-9999.ebuild
@@ -28,7 +28,7 @@ RDEPEND+="
 "
 DEPEND="
 	${RDEPEND}
-	<=sys-devel/llvm-${LLVM_MAX_SLOT}
+	sys-devel/llvm:${LLVM_MAX_SLOT}
 "
 
 if ver_test ${PV} -ne 9999; then


### PR DESCRIPTION
It was trying to pull in `sys-devel/llvm-14` which isn't the desired result.