### PR TITLE
*/*: move {dev-util => app-alternatives}/ninja

### DIFF
--- a/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9.ebuild
+++ b/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9.ebuild
@@ -31,7 +31,7 @@ RDEPEND+="
 	media-libs/zimg"
 DEPEND="${RDEPEND}
 "
-BDEPEND="dev-util/ninja"
+BDEPEND="app-alternatives/ninja"
 
 src_configure() {
 	local emesonargs=(

--- a/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9999.ebuild
+++ b/media-plugins/vapoursynth-rife-ncnn-vulkan/vapoursynth-rife-ncnn-vulkan-9999.ebuild
@@ -31,7 +31,7 @@ RDEPEND+="
 	media-libs/zimg"
 DEPEND="${RDEPEND}
 "
-BDEPEND="dev-util/ninja"
+BDEPEND="app-alternatives/ninja"
 
 src_configure() {
 	local emesonargs=(


### PR DESCRIPTION
fix `media-plugins/vapoursynth-rife-ncnn-vulkan` BDEPEND.