### PR TITLE
media-plugins/vapoursynth-ffmpegsource-9999: .so version updated

### DIFF
--- a/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-9999.ebuild
+++ b/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -27,5 +27,5 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}"
 
 src_install() {
-	dosym ${EPREFIX}/usr/$(get_libdir)/libffms2.so.4.0.0 /usr/$(get_libdir)/vapoursynth/libffms2.so || die
+	dosym ${EPREFIX}/usr/$(get_libdir)/libffms2.so.5.0.0 /usr/$(get_libdir)/vapoursynth/libffms2.so || die
 }


### PR DESCRIPTION
It's libffms2.so.5.0.0 now