### PR TITLE
media-plugins/vapoursynth-mlrt-ncnn: version  bump and fix build

### DIFF
--- a/media-plugins/vapoursynth-mlrt-ncnn/files/0001-vsncnn-Include-mutex.patch
+++ b/media-plugins/vapoursynth-mlrt-ncnn/files/0001-vsncnn-Include-mutex.patch
@@ -1,0 +1,24 @@
+From 1cd9c8f4485a46601e31cb0adccf21b022d4c31f Mon Sep 17 00:00:00 2001
+From: TheGreatMcPain <james@thegreatmcpain.xyz>
+Date: Tue, 25 Jun 2024 02:05:12 -0500
+Subject: [PATCH] vsncnn: Include <mutex>
+
+---
+ vsncnn/vs_ncnn.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vs_ncnn.cpp b/vs_ncnn.cpp
+index 322a7a2..4aba7c3 100644
+--- a/vs_ncnn.cpp
++++ b/vs_ncnn.cpp
+@@ -3,6 +3,7 @@
+ #include <atomic>
+ #include <cstdint>
+ #include <memory>
++#include <mutex>
+ #include <optional>
+ #include <string>
+ #include <string_view>
+-- 
+2.44.2
+

--- a/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-15.ebuild
+++ b/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-15.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2023 Gentoo Authors
+# Copyright 2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake git-r3
+inherit cmake flag-o-matic git-r3
 
 DESCRIPTION="NCNN-based GPU (Vulkan) backend for vs-mlrt"
 HOMEPAGE="https://github.com/AmusementClub/vs-mlrt#vsncnn-ncnn-based-gpu-vulkan-runtime"
@@ -27,6 +27,7 @@ RDEPEND+="
 	sci-libs/onnx
 "
 DEPEND="${RDEPEND}"
+PATCHES="${FILESDIR}/0001-vsncnn-Include-mutex.patch"
 
 S="${S}/vsncnn"
 
@@ -38,6 +39,8 @@ src_prepare() {
 }
 
 src_configure() {
+	append-flags "-DONNX_ML=1"
+	append-flags "-DONNX_NAMESPACE=onnx"
 	local GIT_DISCOVERY_ACROSS_FILESYSTEM=1
 	local mycmakeargs=(
 		-DVAPOURSYNTH_INCLUDE_DIRECTORY="/usr/include/vapoursynth"

--- a/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-9999.ebuild
+++ b/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2023 Gentoo Authors
+# Copyright 2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="NCNN-based GPU (Vulkan) backend for vs-mlrt"
 HOMEPAGE="https://github.com/AmusementClub/vs-mlrt#vsncnn-ncnn-based-gpu-vulkan-runtime"
@@ -28,6 +28,7 @@ RDEPEND+="
 	sci-libs/onnx
 "
 DEPEND="${RDEPEND}"
+PATCHES="${FILESDIR}/0001-vsncnn-Include-mutex.patch"
 
 if ver_test -eq 9999; then
 	S="${S}/vsncnn"
@@ -43,6 +44,8 @@ src_prepare() {
 }
 
 src_configure() {
+	append-flags "-DONNX_ML=1"
+	append-flags "-DONNX_NAMESPACE=onnx"
 	local mycmakeargs=(
 		-DVAPOURSYNTH_INCLUDE_DIRECTORY="/usr/include/vapoursynth"
 	)


### PR DESCRIPTION
Fixes some build issues related to some ONNX stuff not getting defined, and a missing include.