### PR TITLE
media-plugins/vapoursynth-mlrt-ncnn: rebuild with onnx and protobuf, add 15.4

### DIFF
--- a/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-15.4.ebuild
+++ b/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-15.4.ebuild
@@ -23,8 +23,8 @@ IUSE=""
 RDEPEND+="
 	media-libs/vapoursynth
 	dev-libs/ncnn
-	dev-libs/protobuf
-	sci-libs/onnx
+	dev-libs/protobuf:=
+	sci-libs/onnx:=
 "
 DEPEND="${RDEPEND}"
 PATCHES="${FILESDIR}/0001-vsncnn-Include-mutex.patch"

--- a/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-9999.ebuild
+++ b/media-plugins/vapoursynth-mlrt-ncnn/vapoursynth-mlrt-ncnn-9999.ebuild
@@ -24,8 +24,8 @@ IUSE=""
 RDEPEND+="
 	media-libs/vapoursynth
 	dev-libs/ncnn
-	dev-libs/protobuf
-	sci-libs/onnx
+	dev-libs/protobuf:=
+	sci-libs/onnx:=
 "
 DEPEND="${RDEPEND}"
 PATCHES="${FILESDIR}/0001-vsncnn-Include-mutex.patch"


### PR DESCRIPTION
I'm not 100% sure, but I think this breaks if not rebuilt after protobuf, or onnx, updates.

Checking with the merge times for protobuf, and onnx, I assume it's one of them.

The error I got before re-emerging `vapoursynth-mlrt-ncnn`.
```
Failed to load /usr/lib64/vapoursynth/libvsncnn.so. Error given: /usr/lib64/vapoursynth/libvsncnn.so: undefined symbol: _ZN4absl12lts_2023012512log_internal15LogMessageFatalD1Ev
```