### PR TITLE
media-plugins/vapoursynth-havsfunc: backport fixes & add eedi3 dependency

### DIFF
--- a/media-plugins/vapoursynth-havsfunc/files/vapoursynth-havsfunc-33.20220706-rename_lambda_global.patch
+++ b/media-plugins/vapoursynth-havsfunc/files/vapoursynth-havsfunc-33.20220706-rename_lambda_global.patch
@@ -1,0 +1,56 @@
+Backport the following upstream fixes to vapoursynth-havsfunc-33.20220706:
+- https://github.com/HomeOfVapourSynthEvolution/havsfunc/pull/40
+- https://github.com/HomeOfVapourSynthEvolution/havsfunc/pull/41
+These fixes are required for recent vapoursynth versions (>= R57),
+while still being backward compatible with older versions.
+See also https://github.com/HomeOfVapourSynthEvolution/havsfunc/issues/44
+
+--- a/havsfunc.py
++++ b/havsfunc.py
+@@ -1211,8 +1211,8 @@ def QTGMC(Input, Preset='Slower', TR0=None, TR1=None, TR2=None, Rep0=None, Rep1=
+ 
+     # Calculate forward and backward motion vectors from motion search clip
+     if maxTR > 0:
+-        analyse_args = dict(blksize=BlockSize, overlap=Overlap, search=Search, searchparam=SearchParam, pelsearch=PelSearch, truemotion=TrueMotion, _lambda=Lambda, lsad=LSAD, pnew=PNew, plevel=PLevel,
+-                            _global=GlobalMotion, dct=DCT, chroma=ChromaMotion)
++        analyse_args = dict(blksize=BlockSize, overlap=Overlap, search=Search, searchparam=SearchParam, pelsearch=PelSearch, truemotion=TrueMotion, lambda_=Lambda, lsad=LSAD, pnew=PNew, plevel=PLevel,
++                            global_=GlobalMotion, dct=DCT, chroma=ChromaMotion)
+         srchSuper = DitherLumaRebuild(srchClip, s0=1, chroma=ChromaMotion).mv.Super(pel=SubPel, sharp=SubPelInterp, hpad=hpad, vpad=vpad, chroma=ChromaMotion)
+         bVec1 = srchSuper.mv.Analyse(isb=True, delta=1, **analyse_args)
+         fVec1 = srchSuper.mv.Analyse(isb=False, delta=1, **analyse_args)
+@@ -1513,7 +1513,7 @@ def QTGMC(Input, Preset='Slower', TR0=None, TR1=None, TR2=None, Rep0=None, Rep1=
+     rBlockDivide = BlockSize // rBlockSize
+     rLambda = Lambda // (rBlockDivide * rBlockDivide)
+     if ShutterBlur > 1:
+-        recalculate_args = dict(thsad=ThSAD1, blksize=rBlockSize, overlap=rOverlap, search=Search, searchparam=SearchParam, truemotion=TrueMotion, _lambda=rLambda, pnew=PNew, dct=DCT,
++        recalculate_args = dict(thsad=ThSAD1, blksize=rBlockSize, overlap=rOverlap, search=Search, searchparam=SearchParam, truemotion=TrueMotion, lambda_=rLambda, pnew=PNew, dct=DCT,
+                                 chroma=ChromaMotion)
+         sbBVec1 = core.mv.Recalculate(srchSuper, bVec1, **recalculate_args)
+         sbFVec1 = core.mv.Recalculate(srchSuper, fVec1, **recalculate_args)
+@@ -2774,7 +2774,7 @@ def GSMC(input, p=None, Lmask=None, nrmode=None, radius=1, adapt=-1, rep=13, pla
+     psuper = DitherLumaRebuild(pre_nr, s0=1, chroma=chromamv).mv.Super(pel=1, chroma=chromamv)
+     difsuper = dif_nr.mv.Super(pel=1, levels=1, chroma=chromamv)
+ 
+-    analyse_args = dict(blksize=blksize, chroma=chromamv, truemotion=False, _global=True, overlap=overlap)
++    analyse_args = dict(blksize=blksize, chroma=chromamv, truemotion=False, global_=True, overlap=overlap)
+     fv1 = psuper.mv.Analyse(isb=False, delta=1, **analyse_args)
+     bv1 = psuper.mv.Analyse(isb=True, delta=1, **analyse_args)
+     if radius >= 2:
+@@ -3131,7 +3131,7 @@ def MCTemporalDenoise(i, radius=None, pfMode=3, sigma=None, twopass=None, useTTm
+     if refine:
+         rMVS = p.mv.Super(levels=1, **super_args)
+ 
+-    analyse_args = dict(blksize=blksize, search=search, searchparam=searchparam, pelsearch=pelsearch, chroma=chroma, truemotion=truemotion, _global=MVglobal, overlap=overlap, dct=DCT)
++    analyse_args = dict(blksize=blksize, search=search, searchparam=searchparam, pelsearch=pelsearch, chroma=chroma, truemotion=truemotion, global_=MVglobal, overlap=overlap, dct=DCT)
+     recalculate_args = dict(thsad=thSAD // 2, blksize=max(blksize // 2, 4), search=search, chroma=chroma, truemotion=truemotion, overlap=max(overlap // 2, 2), dct=DCT)
+     f1v = pMVS.mv.Analyse(isb=False, delta=1, **analyse_args)
+     b1v = pMVS.mv.Analyse(isb=True, delta=1, **analyse_args)
+@@ -3464,7 +3464,7 @@ def SMDegrain(input, tr=2, thSAD=300, thSADC=None, RefineMotion=False, contrasha
+     # Motion vectors search
+     global bv6, bv4, bv3, bv2, bv1, fv1, fv2, fv3, fv4, fv6
+     super_args = dict(hpad=hpad, vpad=vpad, pel=pel)
+-    analyse_args = dict(blksize=blksize, search=search, chroma=chroma, truemotion=truemotion, _global=MVglobal, overlap=overlap, dct=dct)
++    analyse_args = dict(blksize=blksize, search=search, chroma=chroma, truemotion=truemotion, global_=MVglobal, overlap=overlap, dct=dct)
+     if RefineMotion:
+         recalculate_args = dict(thsad=halfthSAD, blksize=halfblksize, search=search, chroma=chroma, truemotion=truemotion, overlap=halfoverlap, dct=dct)
+ 

--- a/media-plugins/vapoursynth-havsfunc/vapoursynth-havsfunc-33.20220706-r2.ebuild
+++ b/media-plugins/vapoursynth-havsfunc/vapoursynth-havsfunc-33.20220706-r2.ebuild
@@ -1,0 +1,58 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+
+inherit python-single-r1 git-r3
+
+DESCRIPTION="HolyWu's ported AviSynth scripts for VapourSynth"
+HOMEPAGE="http://forum.doom9.org/showthread.php?t=166582"
+
+EGIT_REPO_URI="https://github.com/HomeOfVapourSynthEvolution/havsfunc.git"
+EGIT_COMMIT="21b771350a7e1789a6bc6eb140e98f43a6263710"
+KEYWORDS="~amd64 ~x86"
+
+LICENSE=""
+SLOT="0"
+IUSE="+fftw opencl"
+
+
+RDEPEND+="
+	media-libs/vapoursynth:0/4
+	media-plugins/vapoursynth-addgrain
+	media-plugins/vapoursynth-adjust
+	media-plugins/vapoursynth-awarpsharp2
+	media-plugins/vapoursynth-bilateral
+	media-plugins/vapoursynth-bwdif
+	media-plugins/vapoursynth-cas
+	media-plugins/vapoursynth-ctmf
+	media-plugins/vapoursynth-dctfilter
+	media-plugins/vapoursynth-deblock
+	fftw? ( media-plugins/vapoursynth-dfttest )
+	media-plugins/vapoursynth-eedi2
+	fftw? ( media-plugins/vapoursynth-fft3dfilter )
+	media-plugins/vapoursynth-flash3kyuu_deband
+	media-plugins/vapoursynth-fluxsmooth
+	media-plugins/vapoursynth-fmtconv
+	media-plugins/vapoursynth-hqdn3d
+	opencl? ( >=media-plugins/vapoursynth-knlmeanscl-1.0.2 )
+	media-plugins/vapoursynth-miscfilters-obsolete
+	media-plugins/vapoursynth-mvsfunc
+	fftw? ( media-plugins/vapoursynth-mvtools )
+	opencl? ( media-plugins/vapoursynth-nnedi3cl )
+	media-plugins/vapoursynth-nnedi3_resample
+	media-plugins/vapoursynth-sangnom
+	media-plugins/vapoursynth-temporalsoften2
+	media-plugins/vapoursynth-ttempsmooth
+	media-plugins/vapoursynth-znedi3
+	media-plugins/vsutil
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=("${FILESDIR}/${P}-rename_lambda_global.patch")
+
+src_install(){
+	python_domodule havsfunc.py
+}

--- a/media-plugins/vapoursynth-havsfunc/vapoursynth-havsfunc-33.20220706-r2.ebuild
+++ b/media-plugins/vapoursynth-havsfunc/vapoursynth-havsfunc-33.20220706-r2.ebuild
@@ -32,6 +32,7 @@ RDEPEND+="
 	media-plugins/vapoursynth-deblock
 	fftw? ( media-plugins/vapoursynth-dfttest )
 	media-plugins/vapoursynth-eedi2
+	media-plugins/vapoursynth-eedi3
 	fftw? ( media-plugins/vapoursynth-fft3dfilter )
 	media-plugins/vapoursynth-flash3kyuu_deband
 	media-plugins/vapoursynth-fluxsmooth


### PR DESCRIPTION
Create new revision ebuild vapoursynth-havsfunc-33.20220706-r2 with the following changes:

1. Backport the following upstream fixes to vapoursynth-havsfunc-33.20220706:
- https://github.com/HomeOfVapourSynthEvolution/havsfunc/pull/40
- https://github.com/HomeOfVapourSynthEvolution/havsfunc/pull/41

  These fixes are required for recent vapoursynth versions (>= R57), while still being backward compatible with older versions (see https://github.com/vapoursynth/vapoursynth/commit/617ac8d98ffc5d4d02816284cb1d4dd534b51c65). See also https://github.com/HomeOfVapourSynthEvolution/havsfunc/issues/44

2.  Add dependency on media-plugins/vapoursynth-eedi3 as required by QTGMC_Interpolate helper function inside havsfunc.py:
```
Traceback (most recent call last):
  File "src/cython/vapoursynth.pyx", line 3365, in vapoursynth._vpy_evaluate
  File "src/cython/vapoursynth.pyx", line 3366, in vapoursynth._vpy_evaluate
  File "vapoursynth_processing.vpy", line 26, in <module>
    clip = haf.QTGMC(clip, Preset='Draft', TFF=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/havsfunc.py", line 1316, in QTGMC
    edi1 = QTGMC_Interpolate(ediInput, InputType, EdiMode, NNSize, NNeurons, EdiQual, EdiMaxD, pscrn, int16_prescreener, int16_predictor, exp, alpha, beta, gamma, nrad, vcheck,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/havsfunc.py", line 1585, in QTGMC_Interpolate
    eedi3 = partial(core.eedi3m.EEDI3 if hasattr(core, 'eedi3m') else core.eedi3.eedi3,
                                                                      ^^^^^^^^^^
  File "src/cython/vapoursynth.pyx", line 2873, in vapoursynth._CoreProxy.__getattr__
  File "src/cython/vapoursynth.pyx", line 2696, in vapoursynth.Core.__getattr__
AttributeError: No attribute with the name eedi3 exists. Did you mistype a plugin namespace or forget to install a plugin?
```