### PR TITLE
media-plugins/vs-placebo: Add optional DoVi support

### DIFF
--- a/media-plugins/vs-placebo/vs-placebo-1.4.3-r1.ebuild
+++ b/media-plugins/vs-placebo/vs-placebo-1.4.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,11 +14,15 @@ KEYWORDS="~amd64 ~x86"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="lto"
+IUSE="lto dovi"
 
 RDEPEND+="
 	>=media-libs/libplacebo-4.192.1
 	media-libs/vapoursynth
+	dovi? (
+		media-libs/libdovi
+		>=media-plugins/vapoursynth-ffmpegsource-5.0
+	)
 "
 DEPEND="${RDEPEND}"
 

--- a/media-plugins/vs-placebo/vs-placebo-1.4.4_p20241011.ebuild
+++ b/media-plugins/vs-placebo/vs-placebo-1.4.4_p20241011.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,16 +9,20 @@ DESCRIPTION="libplacebo-based debanding, scaling and color mapping plugin for Va
 HOMEPAGE="https://github.com/Lypheo/vs-placebo"
 
 EGIT_REPO_URI="https://github.com/Lypheo/vs-placebo.git"
-EGIT_COMMIT="2a88143033584f21cc35c13f54b140de4a44621a"
+EGIT_COMMIT="14083805df08cd478539c15464a7183da2c0032e"
 KEYWORDS="~amd64 ~x86"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="lto"
+IUSE="lto dovi"
 
 RDEPEND+="
 	>=media-libs/libplacebo-4.192.1
 	media-libs/vapoursynth
+	dovi? (
+		media-libs/libdovi
+		>=media-plugins/vapoursynth-ffmpegsource-5.0
+	)
 "
 DEPEND="${RDEPEND}"
 

--- a/media-plugins/vs-placebo/vs-placebo-9999.ebuild
+++ b/media-plugins/vs-placebo/vs-placebo-9999.ebuild
@@ -19,11 +19,15 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="lto"
+IUSE="lto dovi"
 
 RDEPEND+="
 	>=media-libs/libplacebo-4.192.1
 	media-libs/vapoursynth
+	dovi? (
+		media-libs/libdovi
+		>=media-plugins/vapoursynth-ffmpegsource-5.0
+	)
 "
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
I just noticed `media-libs/libdovi` was added to Gentoo's main repository.

This adds`dovi` IUSE which will install `libdovi` and `>=FFMS2-5.0`.

vs-placebo's buildsystem will autodetect `libdovi` and enable Dolby Vision support.