### PR TITLE
media-plugins/vapoursynth-vmaf: Gentoo added libvmaf to official repos.

### DIFF
--- a/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-10-r1.ebuild
+++ b/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-10-r1.ebuild
@@ -18,13 +18,13 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-LICENSE=""
+LICENSE="MIT"
 SLOT="0"
 IUSE="lto"
 
 RDEPEND+="
 	media-libs/vapoursynth:0/4
-	sci-libs/vmaf
+	media-libs/libvmaf
 "
 DEPEND="${RDEPEND}
 "

--- a/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-9999-r1.ebuild
+++ b/media-plugins/vapoursynth-vmaf/vapoursynth-vmaf-9999-r1.ebuild
@@ -18,13 +18,13 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-LICENSE=""
+LICENSE="MIT"
 SLOT="0"
 IUSE="lto"
 
 RDEPEND+="
 	media-libs/vapoursynth:0/4
-	sci-libs/vmaf
+	media-libs/libvmaf
 "
 DEPEND="${RDEPEND}
 "


### PR DESCRIPTION
I noticed gentoo added `vmaf` to it's official repository as `media-libs/libvmaf`.