### PR TITLE
media-plugins/vapoursynth-ffmpegsource-9999: Fix broken symlink

### DIFF
--- a/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-9999.ebuild
+++ b/media-plugins/vapoursynth-ffmpegsource/vapoursynth-ffmpegsource-9999.ebuild
@@ -27,5 +27,5 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}"
 
 src_install() {
-	dosym ${EPREFIX}/usr/$(get_libdir)/libffms2.so.5.0.0 /usr/$(get_libdir)/vapoursynth/libffms2.so || die
+	dosym ${EPREFIX}/usr/$(get_libdir)/libffms2.so /usr/$(get_libdir)/vapoursynth/libffms2.so || die
 }


### PR DESCRIPTION
FFMS2's master bumped their library version to 5.0.1 breaking the symlink, so  I've changed `vapoursynth-ffmpegsource-9999` so that it uses `libffms.so` instead of `libffms.so.X.X.X`.

`ffmpegsource-9999` already creates a versionless symlink, so using that for `vapoursynth-ffmpegsource-9999` makes sense.