### PR TITLE
Fix 'TypeIs' import error for vs-jetpack and jetpytools

### DIFF
--- a/dev-python/jetpytools/files/fix-typeis.patch
+++ b/dev-python/jetpytools/files/fix-typeis.patch
@@ -1,0 +1,33 @@
+diff --git a/jetpytools/types/check.py b/jetpytools/types/check.py
+index 3c3d206..c6a72e6 100644
+--- a/jetpytools/types/check.py
++++ b/jetpytools/types/check.py
+@@ -1,6 +1,9 @@
+ from typing import Any, Sequence
+ 
+-from typing_extensions import TypeIs
++try:
++    from typing_extensions import TypeIs
++except:
++    from typing import TypeIs
+ 
+ from .builtins import SoftRange, SoftRangeN, SoftRangesN, StrictRange
+ 
+diff --git a/jetpytools/types/funcs.py b/jetpytools/types/funcs.py
+index d7ca47d..4c94c33 100644
+--- a/jetpytools/types/funcs.py
++++ b/jetpytools/types/funcs.py
+@@ -3,7 +3,12 @@ from __future__ import annotations
+ from functools import wraps
+ from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, SupportsIndex, TypeAlias, overload
+ 
+-from typing_extensions import Self, TypeIs
++from typing_extensions import Self
++
++try:
++    from typing_extensions import TypeIs
++except:
++    from typing import TypeIs
+ 
+ from .builtins import P, T
+ from .supports import SupportsString

--- a/dev-python/jetpytools/jetpytools-1.4.0-r1.ebuild
+++ b/dev-python/jetpytools/jetpytools-1.4.0-r1.ebuild
@@ -19,4 +19,6 @@ KEYWORDS="~amd64 ~x86"
 
 RDEPEND=""
 
+PATCHES="${FILESDIR}/fix-typeis.patch"
+
 distutils_enable_tests pytest

--- a/media-plugins/vs-jetpack/files/fix-typeis.patch
+++ b/media-plugins/vs-jetpack/files/fix-typeis.patch
@@ -1,0 +1,16 @@
+diff --git a/vsmasktools/edge/_abstract.py b/vsmasktools/edge/_abstract.py
+index 1c76d80..0329df2 100644
+--- a/vsmasktools/edge/_abstract.py
++++ b/vsmasktools/edge/_abstract.py
+@@ -5,7 +5,10 @@ from enum import Enum, IntFlag, auto
+ from typing import Any, ClassVar, NoReturn, Sequence, TypeAlias, TypeVar, cast
+ 
+ from jetpytools import CustomNotImplementedError, inject_kwargs_params
+-from typing_extensions import TypeIs
++try:
++    from typing_extensions import TypeIs
++except:
++    from typing import TypeIs
+ 
+ from vsexprtools import ExprOp, ExprToken, norm_expr
+ from vstools import (

--- a/media-plugins/vs-jetpack/vs-jetpack-0.4.0-r2.ebuild
+++ b/media-plugins/vs-jetpack/vs-jetpack-0.4.0-r2.ebuild
@@ -26,6 +26,8 @@ LICENSE="MIT"
 SLOT="0"
 IUSE="cuda opencl vulkan -sourcefilters"
 
+PATCHES="${FILESDIR}/fix-typeis.patch"
+
 RDEPEND+="
 	!media-plugins/vs-aa
 	!media-plugins/vs-dehalo


### PR DESCRIPTION
Looks like `typing-extensions` dropped `TypeIs` at some point, because Python 3.13's `typing` module has it now.