### PR TITLE
media-plugins/vapoursynth-zip: install lib in correct place

### DIFF
--- a/media-plugins/vapoursynth-zip/vapoursynth-zip-7-r1.ebuild
+++ b/media-plugins/vapoursynth-zip/vapoursynth-zip-7-r1.ebuild
@@ -30,3 +30,7 @@ RDEPEND="
 	media-libs/vapoursynth
 "
 DOCS=( "README.md" )
+
+src_install() {
+	zig_src_install --prefix-lib-dir "$(get_libdir)/vapoursynth"
+}


### PR DESCRIPTION
Fixes https://github.com/4re/vapoursynth-portage/issues/163

cf [zig.eclass](https://devmanual.gentoo.org/eclass-reference/zig.eclass/index.html) (actually had to read the source code to see how to affect only libdir).