### PR TITLE
media-plugins/vs-mlrt: use unpacker_src_uri_depends

### DIFF
--- a/media-plugins/vs-mlrt/vs-mlrt-15.14-r1.ebuild
+++ b/media-plugins/vs-mlrt/vs-mlrt-15.14-r1.ebuild
@@ -78,9 +78,7 @@ SLOT="0"
 IUSE="+ncnn +models model-rife model-waifu2x-swin-unet"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-BDEPEND="
-	app-arch/7zip
-"
+BDEPEND="$(unpacker_src_uri_depends)"
 RDEPEND+="
 	${PYTHON_DEPS}
 	media-libs/vapoursynth[${PYTHON_SINGLE_USEDEP}]

--- a/media-plugins/vs-mlrt/vs-mlrt-9999.ebuild
+++ b/media-plugins/vs-mlrt/vs-mlrt-9999.ebuild
@@ -78,9 +78,7 @@ SLOT="0"
 IUSE="+ncnn +models model-rife model-waifu2x-swin-unet"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-BDEPEND="
-	app-arch/7zip
-"
+BDEPEND="$(unpacker_src_uri_depends)"
 RDEPEND+="
 	${PYTHON_DEPS}
 	media-libs/vapoursynth[${PYTHON_SINGLE_USEDEP}]


### PR DESCRIPTION
This avoids a hard dependency on app-arch/7zip and instead allows also other unpackers such as app-arch/p7zip to be used.