### PR TITLE
media-plugins/vapoursynth-{bm3dcuda,bilateralgpu}: CUDA fixes

### DIFF
--- a/media-plugins/vapoursynth-bilateralgpu/vapoursynth-bilateralgpu-10.ebuild
+++ b/media-plugins/vapoursynth-bilateralgpu/vapoursynth-bilateralgpu-10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake cuda
 
 DESCRIPTION="Bilateral filter for VapourSynth based on the OpenCV-CUDA library"
 HOMEPAGE="https://github.com/WolframRhodium/VapourSynth-BilateralGPU"
@@ -27,11 +27,18 @@ RDEPEND+="
 "
 DEPEND="${RDEPEND}
 "
+
+src_prepare() {
+	default
+	cmake_src_prepare
+	cuda_add_sandbox
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_LIBDIR="$(get_libdir)/vapoursynth/"
 		-DVAPOURSYNTH_INCLUDE_DIRECTORY="$(pkg-config --cflags-only-I vapoursynth | sed 's/-I//')"
-		-DCMAKE_CUDA_FLAGS="--threads 0 --use_fast_math -Wno-deprecated-gpu-targets"
+		-DCMAKE_CUDA_FLAGS="--threads 0 --use_fast_math -Wno-deprecated-gpu-targets $(cuda_gccdir -f | tr -d \")"
 	)
 	cmake_src_configure
 }

--- a/media-plugins/vapoursynth-bilateralgpu/vapoursynth-bilateralgpu-9999.ebuild
+++ b/media-plugins/vapoursynth-bilateralgpu/vapoursynth-bilateralgpu-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake cuda
 
 DESCRIPTION="Bilateral filter for VapourSynth based on the OpenCV-CUDA library"
 HOMEPAGE="https://github.com/WolframRhodium/VapourSynth-BilateralGPU"
@@ -27,11 +27,18 @@ RDEPEND+="
 "
 DEPEND="${RDEPEND}
 "
+
+src_prepare() {
+	default
+	cmake_src_prepare
+	cuda_add_sandbox
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_LIBDIR="$(get_libdir)/vapoursynth/"
 		-DVAPOURSYNTH_INCLUDE_DIRECTORY="$(pkg-config --cflags-only-I vapoursynth | sed 's/-I//')"
-		-DCMAKE_CUDA_FLAGS="--threads 0 --use_fast_math -Wno-deprecated-gpu-targets"
+		-DCMAKE_CUDA_FLAGS="--threads 0 --use_fast_math -Wno-deprecated-gpu-targets $(cuda_gccdir -f | tr -d \")"
 	)
 	cmake_src_configure
 }

--- a/media-plugins/vapoursynth-bm3dcuda/vapoursynth-bm3dcuda-2.12.ebuild
+++ b/media-plugins/vapoursynth-bm3dcuda/vapoursynth-bm3dcuda-2.12.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake cuda
 
 DESCRIPTION="BM3D denoising filter for VapourSynth, implemented in CUDA"
 HOMEPAGE="https://github.com/WolframRhodium/VapourSynth-BM3DCUDA"
@@ -33,16 +33,10 @@ RDEPEND+="
 DEPEND="${RDEPEND}
 "
 
-pkg_setup() {
-	# Pulled from firefox ebuild
-	#
-	# Fixes sandbox error
-	if use cuda; then
-		nvidia_cards=$(echo -n /dev/nvidia* | sed 's/ /:/g')
-		if [[ -n "${nvidia_cards}" ]] ; then
-			addpredict "${nvidia_cards}"
-		fi
-	fi
+src_prepare() {
+	default
+	cmake_src_prepare
+	use cuda && cuda_add_sandbox
 }
 
 src_configure() {
@@ -53,5 +47,10 @@ src_configure() {
 		-DENABLE_CPU=$(usex cpu ON OFF)
 		-DENABLE_CUDA=$(usex cuda ON OFF)
 	)
+	if use cuda; then
+		mycmakeargs+=(
+			-DCMAKE_CUDA_FLAGS="$(cuda_gccdir -f | tr -d \")"
+		)
+	fi
 	cmake_src_configure
 }

--- a/media-plugins/vapoursynth-bm3dcuda/vapoursynth-bm3dcuda-9999.ebuild
+++ b/media-plugins/vapoursynth-bm3dcuda/vapoursynth-bm3dcuda-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake cuda
 
 DESCRIPTION="BM3D denoising filter for VapourSynth, implemented in CUDA"
 HOMEPAGE="https://github.com/WolframRhodium/VapourSynth-BM3DCUDA"
@@ -33,16 +33,10 @@ RDEPEND+="
 DEPEND="${RDEPEND}
 "
 
-pkg_setup() {
-	# Pulled from firefox ebuild
-	#
-	# Fixes sandbox error
-	if use cuda; then
-		nvidia_cards=$(echo -n /dev/nvidia* | sed 's/ /:/g')
-		if [[ -n "${nvidia_cards}" ]] ; then
-			addpredict "${nvidia_cards}"
-		fi
-	fi
+src_prepare() {
+	default
+	cmake_src_prepare
+	use cuda && cuda_add_sandbox
 }
 
 src_configure() {
@@ -53,5 +47,10 @@ src_configure() {
 		-DENABLE_CPU=$(usex cpu ON OFF)
 		-DENABLE_CUDA=$(usex cuda ON OFF)
 	)
+	if use cuda; then
+		mycmakeargs+=(
+			-DCMAKE_CUDA_FLAGS="$(cuda_gccdir -f | tr -d \")"
+		)
+	fi
 	cmake_src_configure
 }


### PR DESCRIPTION
Fixes some issues by switching to the `cuda` eclass:

* switches to supported GCC for CUDA (.e. gcc 15 can be installed and system default, but installed gcc 14 will be used for CUDA 12.9 during `emerge`)
* correcly sets up sandbox exceptions (previous manual approach in `ebuild` fails with current portage, as colons are not supported anymore in `addpredict`)